### PR TITLE
Avoid unnecessary bluetooth device address scanning.

### DIFF
--- a/desktop-widgets/downloadfromdivecomputer.cpp
+++ b/desktop-widgets/downloadfromdivecomputer.cpp
@@ -149,6 +149,7 @@ int DownloadFromDCWidget::deviceIndex(QString deviceText)
 void DownloadFromDCWidget::DC##num##Clicked() \
 { \
 	ui.vendor->setCurrentIndex(ui.vendor->findText(qPrefDiveComputer::vendor##num())); \
+	ui.device->setCurrentText(qPrefDiveComputer::device##num()); \
 	productModel.setStringList(productList[qPrefDiveComputer::vendor##num()]); \
 	ui.product->setCurrentIndex(ui.product->findText(qPrefDiveComputer::product##num())); \
 	bool isBluetoothDevice = isBluetoothAddress(qPrefDiveComputer::device##num()); \
@@ -639,10 +640,13 @@ void DownloadFromDCWidget::enableBluetoothMode(int state)
 {
 	ui.chooseBluetoothDevice->setEnabled(state == Qt::Checked);
 
-	if (state == Qt::Checked)
-		selectRemoteBluetoothDevice();
-	else
-		ui.device->setCurrentIndex(-1);
+	if (state == Qt::Checked) {
+      		if (ui.device->currentText().isEmpty()) {
+         		selectRemoteBluetoothDevice();
+   		} else {
+      			ui.device->setCurrentIndex(-1);
+   		}
+	}
 }
 #endif
 


### PR DESCRIPTION
When switching from a non-bluetooth computer to a bluetooh computer an unnecessary bluetooth scan may be forced.   This patch will avoid the scan if the bluetooth device address is known.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
I discovered this issue when sharing a laptop to upload dives.    If I upload dives using a bluetooth computer I have to rescan the device address after a dive is uploaded with a different computer.    This change uses the existing device address instead of scanning.    A scan can be forces by clearing/rechecking the "Choose Bluetooth download mode" checkbox.

### Changes made:
There are two changes.    First, set the device address using the prefs value when a dive computer is selected.    Second, avoid scanning if the device address is already known.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
